### PR TITLE
Update site hero to show Conference Schedule instead of Buy Tickets

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,8 +7,12 @@ layout: base
     <div class="column small-12 medium-7 header-text">
       <h1>Six days of talks, sprints, and tutorials in San Diego</h1>
 
-      <a class="button" href="{{ site.ticket_link }}">Buy Tickets</a>
-      {% comment %}<a href="{{ site.cfp_application }}" class="button">Submit Talk</a>{% endcomment %}
+      <a class="button" href="/schedule">Conference Schedule</a>
+      
+      {% comment %}
+        <a class="button" href="{{ site.ticket_link }}">Buy Tickets</a>
+        <a href="{{ site.cfp_application }}" class="button">Submit Talk</a>
+      {% endcomment %}
 
       <a
         class="button"


### PR DESCRIPTION
Changes proposed in this PR:

- Updates the hero link from `Buy Tickets` to `Conference Schedule`, because the conference has already started and a quick link to the schedule would be beneficial for all attendees.

